### PR TITLE
fix: battery drain when using dbus-broker

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -34,7 +34,7 @@ WrapFuncType = TypeVar("WrapFuncType", bound=Callable[..., Any])
 DEFAULT_ATTEMPTS = 3
 
 # How long to wait before processing an advertisement change
-ADV_UPDATE_COALESCE_SECONDS = 2.99
+ADV_UPDATE_COALESCE_SECONDS = 6.99
 
 # How long to wait before processing the first update
 FIRST_UPDATE_COALESCE_SECONDS = 0.50


### PR DESCRIPTION
dbus-broker is capable of updating the lock much faster
so we end up in a loop of retriggering the update flag

this likely won't be a problem in haos 9.x but best to adjust it now