### PR TITLE
fix: drop connection instead of executing shutdown

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -200,10 +200,7 @@ class Lock:
         if not self.client or not self.client.is_connected:
             return
 
-        try:
-            await self._shutdown_connection()
-        finally:
-            await self.client.disconnect()
+        await self.client.disconnect()
 
     async def _shutdown_connection(self) -> None:
         """Shutdown the connection."""


### PR DESCRIPTION
The locks work just fine with dropping the connection instead of executing the shutdown and since we hold the connection for a shorter time, it should save
some battery