### PR TITLE
fix: improve operation reliability

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -98,6 +98,11 @@ class Lock:
             self.client, self.name, self._lock, self.key_index
         )
 
+        # Order matters here, we must start notify for the secure session before
+        # the non-secure session
+        await self.secure_session.start_notify()
+        await self.session.start_notify()
+
         self.secure_session.set_key(self.key)
         handshake_keys = os.urandom(16)
 

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -118,20 +118,7 @@ class Session:
             util._copy(command, cipherText)
 
         _LOGGER.debug("%s: Encrypted command: %s", self.name, command.hex())
-
         future: asyncio.Future[bytes] = asyncio.Future()
-
-        if not self._notifications_started:
-            _LOGGER.debug("%s: Starting notify for %s", self.name, type(self))
-            try:
-                await self._start_notify(self._notify)
-            except BleakError as err:
-                _LOGGER.debug("%s: Failed to start notify: %s", self.name, err)
-                if "not found" in str(err):
-                    raise AuthError(f"{self.name}: {err}") from err
-                raise
-            self._notifications_started = True
-
         self._notify_future = future
         _LOGGER.debug(
             "%s: Writing command to %s: %s",
@@ -145,6 +132,19 @@ class Session:
             result = await future
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
         return result
+
+    async def start_notify(self) -> None:
+        """Start notify."""
+        if not self._notifications_started:
+            _LOGGER.debug("%s: Starting notify for %s", self.name, type(self))
+            try:
+                await self._start_notify(self._notify)
+            except BleakError as err:
+                _LOGGER.debug("%s: Failed to start notify: %s", self.name, err)
+                if "not found" in str(err):
+                    raise AuthError(f"{self.name}: {err}") from err
+                raise
+            self._notifications_started = True
 
     async def _start_notify(self, callback: Callable[[int, bytearray], None]) -> None:
         """Start notify."""


### PR DESCRIPTION
We now start notify at the top of the session to
make sure its setup in time since the lock seems
to have an internal race where its not set soon
enough