### PR TITLE
fix: free up the connection faster after first update

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -478,7 +478,10 @@ class PushLock:
     async def _update(self) -> LockState:
         """Update the lock state."""
         has_lock_info = self._lock_info is not None
-        _LOGGER.debug("%s: Starting update", self.name)
+
+        _LOGGER.debug(
+            "%s: Starting update (has_lock_info: %s)", self.name, has_lock_info
+        )
         try:
             lock = await self._ensure_connected()
             if not self._lock_info:


### PR DESCRIPTION
Proxies can run out of connection slots if there
are a lot of locks that need to be brought up