### PR TITLE
fix: ensure we still disconnect if the write times out

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -325,8 +325,10 @@ class Lock:
         if not self.client or not self.client.is_connected:
             return
 
-        await self._shutdown_connection()
-        await self.client.disconnect()
+        try:
+            await self._shutdown_connection()
+        finally:
+            await self.client.disconnect()
 
     async def _shutdown_connection(self) -> None:
         """Shutdown the connection."""

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -151,10 +151,12 @@ class Session:
                 self.write_characteristic,
                 command.hex(),
             )
-            await self.client.write_gatt_char(self.write_characteristic, command, True)
             _LOGGER.debug("%s: Waiting for response", self.name)
-            async with async_timeout.timeout(5):
+            async with async_timeout.timeout(10):
                 try:
+                    await self.client.write_gatt_char(
+                        self.write_characteristic, command, True
+                    )
                     result = await future
                 except ResponseError:
                     _LOGGER.debug("%s: Invalid response, retrying", self.name)


### PR DESCRIPTION
If we start getting timesouts we need to disconnect and reconnect to recover