### PR TITLE
fix: delay disconnect after initial sync if another sync is pending

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -56,7 +56,7 @@ RESYNC_DELAY = 0.01
 
 # Number of seconds to wait after the first connection
 # to disconnect to free up the bluetooth adapter.
-FIRST_CONNECTION_DISCONNECT_TIME = 1.1
+FIRST_CONNECTION_DISCONNECT_TIME = 2.1
 
 # After a lock operation we need to wait for the lock to
 # update its state or it will return a stale state.

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -344,7 +344,7 @@ class PushLock:
             self._lock_info,
         )
 
-    def _reset_disconnect_timer(self, seconds: float | None = None) -> None:
+    def _reset_disconnect_timer(self) -> None:
         """Reset disconnect timer."""
         self._cancel_disconnect_timer()
         self._expected_disconnect = False

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -349,6 +349,9 @@ class PushLock:
         self._cancel_disconnect_timer()
         self._expected_disconnect = False
         timeout = self._next_disconnect_delay
+        _LOGGER.debug(
+            "%s: Resetting disconnect timer to %s seconds", self.name, timeout
+        )
         self._disconnect_timer = self.loop.call_later(
             timeout, self._disconnect_with_timer, timeout
         )

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -56,7 +56,7 @@ RESYNC_DELAY = 0.01
 
 # Number of seconds to wait after the first connection
 # to disconnect to free up the bluetooth adapter.
-FIRST_CONNECTION_DISCONNECT_TIME = 0.5
+FIRST_CONNECTION_DISCONNECT_TIME = 1.1
 
 # After a lock operation we need to wait for the lock to
 # update its state or it will return a stale state.

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -56,7 +56,7 @@ RESYNC_DELAY = 0.01
 
 # Number of seconds to wait after the first connection
 # to disconnect to free up the bluetooth adapter.
-FIRST_CONNECTION_DISCONNECT_TIME = 0.1
+FIRST_CONNECTION_DISCONNECT_TIME = 0.5
 
 # After a lock operation we need to wait for the lock to
 # update its state or it will return a stale state.


### PR DESCRIPTION
This seems like a good balance of freeing up the connection slot but not reconnecting to do a double update with all the models I have.