### PR TITLE
fix: implement a cooldown between commands

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -258,6 +258,8 @@ class Lock:
                 + response.hex()
             )
         self.session.set_key(session_key)
+        self.secure_session.enable_cooldown()
+        self.session.enable_cooldown()
 
     @raise_if_not_connected
     async def lock_info(self) -> LockInfo:

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -172,7 +172,6 @@ class Lock:
         # Order matters here, we must start notify for the secure session before
         # the non-secure session
         await self.secure_session.start_notify()
-        await self.session.start_notify()
         try:
             await self._setup_session()
         except BleakError as err:
@@ -180,6 +179,7 @@ class Lock:
             if "invalid handle" in error_desc:
                 await self._handle_missing_characteristic(error_desc)
             raise err
+        await self.session.start_notify()
 
     async def _handle_missing_characteristic(self, char_uuid: str) -> None:
         """Handle missing characteristic."""

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -577,8 +577,10 @@ class PushLock:
         # Asking for battery first seems to be reduce the chance of the lock
         # getting into a bad state.
         battery_state = await lock.battery()
-        # Only ask for the lock status if have it and notify
-        # has been active.
+        # Only ask for the lock status if we haven't seen
+        # it this session since notify callbacks will happen
+        # if it changes and the extra polling can cause the lock
+        # to get into a bad state.
         if not self._already_seen_status_this_session():
             state = await lock.status()
         self._auth_failures = 0

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -560,8 +560,8 @@ class PushLock:
         lock = await self._ensure_connected()
         if not self._lock_info:
             self._lock_info = await lock.lock_info()
-        state = await lock.status()
         battery_state = await lock.battery()
+        state = await lock.status()
         self._auth_failures = 0
         state = replace(state, battery=battery_state, auth=AuthState(successful=True))
         _LOGGER.debug("%s: Finished update", self.name)

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -229,6 +229,9 @@ class PushLock:
         self._cancel_deferred_update: asyncio.TimerHandle | None = None
         self._client: Lock | None = None
         self._connect_lock = asyncio.Lock()
+        self._seen_this_session: set[
+            type[LockStatus] | type[DoorStatus] | type[BatteryState] | type[AuthState]
+        ] = set()
         self._disconnect_timer: asyncio.TimerHandle | None = None
         self._idle_disconnect_delay = idle_disconnect_delay
         self._next_disconnect_delay = idle_disconnect_delay
@@ -452,6 +455,7 @@ class PushLock:
                 raise
             self._next_disconnect_delay = self._idle_disconnect_delay
             self._reset_disconnect_timer()
+            self._seen_this_session.clear()
             return self._client
 
     async def lock(self) -> None:
@@ -507,6 +511,8 @@ class PushLock:
         )
         original_lock_status = lock_state.lock
         for state in states:
+            state_type = type(state)
+            self._seen_this_session.add(state_type)
             if isinstance(state, AuthState):
                 lock_state = replace(lock_state, auth=state)
             elif isinstance(state, LockStatus):
@@ -548,6 +554,14 @@ class PushLock:
         await self._update()
         _LOGGER.debug("%s: Finished validate", self.name)
 
+    def _already_seen_status_this_session(self) -> bool:
+        """Return True if we have seen all states this session."""
+        if type(LockStatus) not in self._seen_this_session:
+            return False
+        if self._lock_info and self._lock_info.door_sense:
+            return type(DoorStatus) in self._seen_this_session
+        return True
+
     @operation_lock
     @retry_bluetooth_connection_error
     async def _update(self) -> LockState:
@@ -560,8 +574,13 @@ class PushLock:
         lock = await self._ensure_connected()
         if not self._lock_info:
             self._lock_info = await lock.lock_info()
+        # Asking for battery first seems to be reduce the chance of the lock
+        # getting into a bad state.
         battery_state = await lock.battery()
-        state = await lock.status()
+        # Only ask for the lock status if have it and notify
+        # has been active.
+        if not self._already_seen_status_this_session():
+            state = await lock.status()
         self._auth_failures = 0
         state = replace(state, battery=battery_state, auth=AuthState(successful=True))
         _LOGGER.debug("%s: Finished update", self.name)

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import time
 from typing import Callable
 
 import async_timeout
@@ -19,6 +20,8 @@ from . import util
 from .const import READ_CHARACTERISTIC, WRITE_CHARACTERISTIC
 
 _LOGGER = logging.getLogger(__name__)
+
+COOLDOWN_TIME = 0.25
 
 
 class YaleXSBLEError(Exception):
@@ -74,6 +77,7 @@ class Session:
         self._state_callback = state_callback
         self._disconnected_event = disconnected_event
         self._first_request = True
+        self._last_callback_time = -86400.0
 
     def set_key(self, key: bytes) -> None:
         self.cipher_encrypt = Cipher(
@@ -128,6 +132,7 @@ class Session:
             return await self._locked_write(command, command_name)
 
     def _notify(self, char: int, data: bytes) -> None:
+        self._last_callback_time = time.monotonic()
         _LOGGER.debug(
             "%s: Receiving response via notify: %s (waiting=%s)",
             self.name,
@@ -235,6 +240,13 @@ class Session:
 
     async def execute(self, command: bytearray, command_name: str) -> bytes:
         """Execute command."""
+        while (
+            cooldown_remain := time.monotonic() - self._last_callback_time
+        ) < COOLDOWN_TIME:
+            _LOGGER.debug(
+                "%s: Waiting %s for lock to settle", self.name, cooldown_remain
+            )
+            await asyncio.sleep(COOLDOWN_TIME - cooldown_remain)
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
         self._write_checksum(command)
         write_task = asyncio.create_task(self._write(command, command_name))

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -246,6 +246,9 @@ class Session:
             _LOGGER.debug(
                 "%s: Waiting %s for lock to settle", self.name, cooldown_remain
             )
+            # If we send commands to fast the lock may crash and stop
+            # advertising. This is a workaround to avoid that since
+            # it means a battery pull is required to recover.
             await asyncio.sleep(COOLDOWN_TIME - cooldown_remain)
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
         self._write_checksum(command)

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -246,8 +246,10 @@ class Session:
     async def execute(self, command: bytearray, command_name: str) -> bytes:
         """Execute command."""
         while (
-            cooldown_remain := time.monotonic() - self._last_callback_time
-        ) < COOLDOWN_TIME:
+            self._enable_cooldown
+            and (cooldown_remain := time.monotonic() - self._last_callback_time)
+            < COOLDOWN_TIME
+        ):
             _LOGGER.debug(
                 "%s: Waiting %s for lock to settle", self.name, cooldown_remain
             )

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -78,6 +78,7 @@ class Session:
         self._disconnected_event = disconnected_event
         self._first_request = True
         self._last_callback_time = -86400.0
+        self._enable_cooldown = False
 
     def set_key(self, key: bytes) -> None:
         self.cipher_encrypt = Cipher(
@@ -86,6 +87,10 @@ class Session:
         self.cipher_decrypt = Cipher(
             algorithms.AES(key), modes.CBC(bytes(0x10))  # nosec
         ).decryptor()
+
+    def enable_cooldown(self) -> None:
+        """Enable cooldown after each request."""
+        self._enable_cooldown = True
 
     def decrypt(self, data: bytes | bytearray) -> bytes:
         if self.cipher_decrypt is not None:


### PR DESCRIPTION
The assure 2s seem to crash if there are too many commands close together. The symptom is they stop responding and stop advertising