### PR TITLE
fix: handling of cancellation of first update

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -757,11 +757,13 @@ class PushLock:
         try:
             async with async_timeout.timeout(timeout):
                 await self._first_update_future
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, asyncio.CancelledError) as ex:
             self._first_update_future.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._first_update_future
-            raise NoAdvertisementError("No advertisement received")
+            raise NoAdvertisementError(
+                "No advertisement received before timeout"
+            ) from ex
         finally:
             self._first_update_future = None
 


### PR DESCRIPTION
```
2023-04-25 16:12:42.597 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Garage Side Door for yalexs_ble
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 385, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/yalexs_ble/__init__.py", line 64, in async_setup_entry
    await push_lock.wait_for_first_update(DEVICE_TIMEOUT)
  File "/usr/local/lib/python3.10/site-packages/yalexs_ble/push.py", line 759, in wait_for_first_update
    await self._first_update_future
asyncio.exceptions.CancelledError
```