### PR TITLE
fix: only try to connect once at startup

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -9,6 +9,7 @@ from typing import Any, TypeVar, cast
 
 from bleak import BleakError
 from bleak_retry_connector import (
+    MAX_CONNECT_ATTEMPTS,
     BleakClientWithServiceCache,
     BLEDevice,
     establish_connection,
@@ -133,7 +134,7 @@ class Lock:
         if self._disconnect_callback:
             self._disconnect_callback()
 
-    async def connect(self) -> None:
+    async def connect(self, max_attempts: int = MAX_CONNECT_ATTEMPTS) -> None:
         """Connect to the lock."""
         _LOGGER.debug(
             "%s: Connecting to the lock",
@@ -147,6 +148,7 @@ class Lock:
                 self.disconnected,
                 use_services_cache=True,
                 ble_device_callback=self.ble_device_callback,
+                max_attempts=max_attempts,
             )
         except (asyncio.TimeoutError, BleakError) as err:
             _LOGGER.error("%s: Failed to connect to the lock: %s", self.name, err)


### PR DESCRIPTION
We should only try to connect once at startup since each attempt can take up to 25s which means we could delay startup by 2m. If it fails the first time it can be retried later.

Since HA times out after 55s, there is a risk we have a cancellation race where we tear down even though it was successful which can get locks into a bad state