### PR TITLE
fest: add basic support for activities

### DIFF
--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -54,6 +54,7 @@ class DoorStatus(Enum):
 
 VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 
+
 class LockActivityType(Enum):
     LOCK = 0x00
     DOOR = 0x20
@@ -77,6 +78,7 @@ class LockState:
 class LockActivity:
     timestamp: datetime
     status: LockStatus
+
 
 @dataclass
 class DoorActivity:

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -58,6 +58,7 @@ VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 class LockActivityType(Enum):
     LOCK = 0x00
     DOOR = 0x20
+    NONE = 0x80
 
 
 @dataclass

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TypedDict
 from datetime import datetime
-from typing import Optional
 
 COMMAND_SERVICE_UUID = "0000fe24-0000-1000-8000-00805f9b34fb"
 WRITE_CHARACTERISTIC = "bd4ac611-0b45-11e3-8ffd-0800200c9a66"
@@ -59,7 +58,7 @@ VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 class LockActivityType(Enum):
     LOCK = 0x00
     DOOR = 0x20
-    PIN = 0x0e
+    PIN = 0x0E
     NONE = 0x80
 
 
@@ -81,7 +80,7 @@ class LockState:
 class LockActivity:
     timestamp: datetime
     status: LockStatus
-    slot: Optional[int] = None
+    slot: int | None = None
 
 
 @dataclass

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import TypedDict
+from datetime import datetime
 
 COMMAND_SERVICE_UUID = "0000fe24-0000-1000-8000-00805f9b34fb"
 WRITE_CHARACTERISTIC = "bd4ac611-0b45-11e3-8ffd-0800200c9a66"
@@ -27,6 +28,7 @@ NO_DOOR_SENSE_MODELS = {"ASL-02", "ASL-01"}
 class Commands(Enum):
     UNLOCK = 0x0A
     LOCK = 0x0B
+    LOCK_ACTIVITY = 0x2D
 
 
 class LockStatus(Enum):
@@ -52,6 +54,10 @@ class DoorStatus(Enum):
 
 VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 
+class LockActivityType(Enum):
+    LOCK = 0x00
+    DOOR = 0x20
+
 
 @dataclass
 class BatteryState:
@@ -65,6 +71,17 @@ class LockState:
     door: DoorStatus
     battery: BatteryState | None
     auth: AuthState | None
+
+
+@dataclass
+class LockActivity:
+    timestamp: datetime
+    status: LockStatus
+
+@dataclass
+class DoorActivity:
+    timestamp: datetime
+    status: DoorStatus
 
 
 @dataclass

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TypedDict
 from datetime import datetime
+from typing import Optional
 
 COMMAND_SERVICE_UUID = "0000fe24-0000-1000-8000-00805f9b34fb"
 WRITE_CHARACTERISTIC = "bd4ac611-0b45-11e3-8ffd-0800200c9a66"
@@ -58,6 +59,7 @@ VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 class LockActivityType(Enum):
     LOCK = 0x00
     DOOR = 0x20
+    PIN = 0x0e
     NONE = 0x80
 
 
@@ -79,6 +81,7 @@ class LockState:
 class LockActivity:
     timestamp: datetime
     status: LockStatus
+    slot: Optional[int] = None
 
 
 @dataclass

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -431,7 +431,17 @@ class Lock:
             # Lock status is at 0x06
             timestamp = self._parse_unix_timestamp(response[0x08:0x0C])
             lock_status = self._parse_lock_status(response[0x06])
+
             return LockActivity(timestamp, lock_status)
+        elif activity_type == LockActivityType.PIN.value:
+            # Timestamp is at 0x05-0x08
+            # Slot is at 0x10
+            # Lock status seems to be at lower half of 0x0C
+            timestamp = self._parse_unix_timestamp(response[0x05:0x09])
+            pin_slot = response[0x10]
+            lock_status = self._parse_lock_status(response[0x0C] & 0x0F)
+
+            return LockActivity(timestamp, lock_status, pin_slot)
         _LOGGER.warning("%s: Unknown activity type: 0x%02X", self.name, activity_type)
         return None
 

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -416,6 +416,10 @@ class Lock:
         # format seems to be specific to each individual activity type
         activity_type = response[0x04]
         _LOGGER.debug("%s: Activity type: 0x%02X", self.name, activity_type)
+        if activity_type == LockActivityType.NONE.value:
+            _LOGGER.debug("%s: No activity", self.name)
+            return None
+
         if activity_type == LockActivityType.DOOR.value:
             # Timestamp is at 0x05-0x08
             # Door status is at 0x09

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -213,7 +213,7 @@ class Lock:
         _LOGGER.debug("%s: State changed: %s", self.name, state.hex())
         if state[0] == 0xBB:
             if state[1] == Commands.LOCK_ACTIVITY.value:
-                return # Ignore lock activity as these are historical events
+                return  # Ignore lock activity as these are historical events
             if state[4] == 0x02:  # lock only
                 lock_status = state[0x08]
                 self._state_callback(

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -212,6 +212,8 @@ class Lock:
         """Handle state change."""
         _LOGGER.debug("%s: State changed: %s", self.name, state.hex())
         if state[0] == 0xBB:
+            if state[1] == Commands.LOCK_ACTIVITY.value:
+                return # Ignore lock activity as these are historical events
             if state[4] == 0x02:  # lock only
                 lock_status = state[0x08]
                 self._state_callback(

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -434,6 +434,7 @@ class Lock:
     @raise_if_not_connected
     async def lock_activity(self) -> DoorActivity | LockActivity | None:
         _LOGGER.debug("%s: Executing lock_activity", self.name)
+        assert self.session is not None  # nosec
         response = await self.session.execute(
             self.session.build_command(Commands.LOCK_ACTIVITY.value), "lock_activity"
         )

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -394,19 +394,23 @@ class Lock:
         response = await self._execute_command(0x0F, "battery")
         _LOGGER.debug("%s: Finished executing battery", self.name)
         return self._parse_battery_state(response)
-    
+
     def _parse_unix_timestamp(self, timestamp_bytes: bytes) -> datetime:
         """Parse the unix timestamp to datetime from the bytes."""
-        _LOGGER.debug("%s: Parsing unix timestamp: %s", self.name, timestamp_bytes.hex())
+        _LOGGER.debug(
+            "%s: Parsing unix timestamp: %s", self.name, timestamp_bytes.hex()
+        )
         unix_timestamp = int.from_bytes(timestamp_bytes, byteorder="little")
         _LOGGER.debug("%s: Parsed unix timestamp: %d", self.name, unix_timestamp)
         return datetime.fromtimestamp(unix_timestamp)
 
-    def _parse_lock_activity(self, response: bytes) -> DoorActivity | LockActivity | None:
+    def _parse_lock_activity(
+        self, response: bytes
+    ) -> DoorActivity | LockActivity | None:
         """Parse the lock activity from the response."""
         # We only know a subset of lock activities currently
         # response[0x04] seems to be the activity type
-        # the rest of the response is data for the activity, 
+        # the rest of the response is data for the activity,
         # format seems to be specific to each individual activity type
         activity_type = response[0x04]
         _LOGGER.debug("%s: Activity type: 0x%02X", self.name, activity_type)

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -406,9 +406,8 @@ class Lock:
         """Parse the lock activity from the response."""
         # We only know a subset of lock activities currently
         # response[0x04] seems to be the activity type
-        # the rest of the response is data for the activity
-        # response[0x05-0x08] is the timestamp
-        # response[0x09] (and onwards?) is the data for the activity
+        # the rest of the response is data for the activity, 
+        # format seems to be specific to each individual activity type
         activity_type = response[0x04]
         _LOGGER.debug("%s: Activity type: 0x%02X", self.name, activity_type)
         if activity_type == LockActivityType.DOOR.value:


### PR DESCRIPTION
Discovered that a Lock Activity can be fetched using the `0x2D` command.

It seems its execution fetches one activity - Once it's fetched, the next execution will fetch the next activity. From what I can gather, it's first-in first-out i.e. the oldest activities are retrieved first. **Activities fetched here will not be visible in the Yale app**. I have not tested what happens if there are no activities waiting.

The activity type seem to be located at `response[0x04]`, i.e. the fifth byte

Comparing with my app, I've managed to figure out (parts of?) two activities:
* Door activity - Happens when door is opened or closed and presumably any other of the door statuses as well 
* Lock activity - Happens when unlocked or locked.

While the timestamp is located right next to the activity byte for door activities, there's some gaps in the data for locks - Namely `response[0x05]` and `response[0x07]`. My expectation is that it contains some of the metadata that can also be seen in the app (i.e. who unlocked or locked the door), but I did not have the time at the moment to explore further on that part.


The PR is not fully complete as I am piggybacking on the `execute` function in session that will try to update the state based on the response - not really ideal since the states here are historical data... If you have the time to polish the PR, please do so - Just wanted to share my discovery :)