### PR TITLE
fix: add Yale Linus L2 Nordic to models without battery support

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -107,6 +107,7 @@ AUTH_FAILURE_TO_START_REAUTH = 5
 NO_BATTERY_SUPPORT_MODELS = {
     "SL-103",  # Linus L2
     "CERES",  # Smart code handle
+    "Yale Linus L2",  # Linus L2 Nordic
 }
 
 AUTO_LOCK_DEFAULT_DURATION = 90

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -137,4 +137,5 @@ async def test_retry_bluetooth_connection_error_with_operation_lock():
 def test_needs_battery_workaround():
     assert "SL-103" in NO_BATTERY_SUPPORT_MODELS
     assert "CERES" in NO_BATTERY_SUPPORT_MODELS
+    assert "Yale Linus L2" in NO_BATTERY_SUPPORT_MODELS
     assert "ASL-03" not in NO_BATTERY_SUPPORT_MODELS


### PR DESCRIPTION
Tried to add Yale Linus L2 Nordic in home assistant using `Yale Access Bluetooth` integration and got the same problem as in https://github.com/home-assistant/core/issues/125086. I used the BT Inspector app on IOS to check how the lock identifies itself. It seems that the Nordic version of L2 Linus identifies as Yale Linus L2 so I just added it to the `NO_BATTERY_SUPPORT_MODELS` list.

<img width="456" height="440" alt="image" src="https://github.com/user-attachments/assets/8a25475d-870c-4c8c-b8a8-9361ecb6b004" />


I tested to add the lock again with this change and now it works (but without push updates from the lock).