### PR TITLE
fix: add Yale Durus MD-04I to NO_BATTERY_SUPPORT_MODELS

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -108,6 +108,7 @@ NO_BATTERY_SUPPORT_MODELS = {
     "SL-103",  # Linus L2
     "CERES",  # Smart code handle
     "Yale Linus L2",  # Linus L2 Nordic
+    "MD-04I",  # Yale Durus (EU)
 }
 
 AUTO_LOCK_DEFAULT_DURATION = 90


### PR DESCRIPTION
I solved https://github.com/Yale-Libs/yalexs-ble/issues/279 by adding the Durus model MD-04I to the NO_BATTERY_SUPPORT_MODELS list.

I tested it in my local Home Assistant installation and at least it allowed the integration to complete the door setup and make the door lockable/unlockable via BLE proxy.
