### PR TITLE
fix: mypy 2.1.0 bytes/bytearray compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.9
+    rev: v4.16.4
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -39,7 +39,7 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.18
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies: []

--- a/src/yalexs_ble/secure_session.py
+++ b/src/yalexs_ble/secure_session.py
@@ -34,7 +34,7 @@ class SecureSession(Session):
             self._read_characteristic
         )
 
-    def set_key(self, key: bytes) -> None:
+    def set_key(self, key: bytes | bytearray) -> None:
         self.cipher_encrypt = Cipher(  # nosec
             algorithms.AES(key), modes.ECB()
         ).encryptor()
@@ -54,7 +54,7 @@ class SecureSession(Session):
         checksum_bytes = checksum.to_bytes(4, byteorder="little", signed=False)
         util._copy(command, checksum_bytes, destLocation=0x0C)
 
-    def _validate_response(self, data: bytes) -> None:
+    def _validate_response(self, data: bytes | bytearray) -> None:
         response_checksum = int.from_bytes(
             data[0x0C:0x10], byteorder="little", signed=False
         )

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -80,7 +80,7 @@ class Session:
         self._enable_cooldown = False
         self.loop = asyncio.get_running_loop()
 
-    def set_key(self, key: bytes) -> None:
+    def set_key(self, key: bytes | bytearray) -> None:
         self.cipher_encrypt = Cipher(
             algorithms.AES(key),
             modes.CBC(bytes(0x10)),  # nosec
@@ -102,7 +102,7 @@ class Session:
                 data = bytearray(data)
             util._copy(data, plainText)
 
-        return data
+        return bytes(data)
 
     def build_operation_command(self, opcode: int, cmd_byte: int) -> bytearray:
         """Build a command to send to the lock."""
@@ -138,7 +138,7 @@ class Session:
         async with self._lock:
             return await self._locked_write(command, command_name)
 
-    def _notify(self, char: int, data: bytes) -> None:
+    def _notify(self, char: int, data: bytearray) -> None:
         self._last_callback_time = time.monotonic()
         _LOGGER.debug(
             "%s: Receiving response via notify: %s (waiting=%s)",

--- a/src/yalexs_ble/util.py
+++ b/src/yalexs_ble/util.py
@@ -10,7 +10,7 @@ from bleak.backends.scanner import AdvertisementData
 UNIQUE_LOCAL_NAME_LEN = 7
 
 
-def _simple_checksum(buf: bytes) -> int:
+def _simple_checksum(buf: bytes | bytearray) -> int:
     cs = 0
     for i in range(0x12):
         cs = (cs + buf[i]) & 0xFF
@@ -18,7 +18,7 @@ def _simple_checksum(buf: bytes) -> int:
     return (-cs) & 0xFF
 
 
-def _bytes_to_int(buffer: bytes) -> int:
+def _bytes_to_int(buffer: bytes | bytearray) -> int:
     """Convert a byte buffer to an integer."""
     return int.from_bytes(buffer, byteorder="little", signed=False)
 
@@ -30,7 +30,7 @@ def _int_to_bytes(value: int, length: int) -> bytes:
     return value.to_bytes(length, byteorder="little", signed=False)
 
 
-def _security_checksum(buffer: bytes) -> int:
+def _security_checksum(buffer: bytes | bytearray) -> int:
     val1 = _bytes_to_int(buffer[0x00:0x04])
     val2 = _bytes_to_int(buffer[0x04:0x08])
     val3 = _bytes_to_int(buffer[0x08:0x12])


### PR DESCRIPTION
mypy 2.1.0 (bumped in #313) dropped the implicit bytearray to bytes promotion, so the lint job started failing with 9 type errors. This widens the read only buffer params in util, session, and secure_session to accept bytes or bytearray, fixes the LSP override on _validate_response, and converts decrypt to return bytes; behavior is unchanged. Includes the pre-commit bump from #313 so the lint check passes here, this can supersede #313.