### PR TITLE
fix: jam detection — decode the operation-response result from byte[15]; decode status 0x07 as JAMMED

### DIFF
--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -34,6 +34,64 @@ class Commands(IntEnum):
     LOCK_ACTIVITY = 0x2D
 
 
+class OperationError(IntEnum):
+    """Operation result reported in byte[15] of an op-response (BB 0A/0B).
+
+    0x00 = success; any non-zero value is a failure (0x1E-0x23 are the
+    MECH_* motor faults, i.e. a stalled motor / jam). Non-mechanical
+    failures (credential, battery, wifi, calibration) are included for
+    logging so a failure report names the actual cause.
+    """
+
+    COMM_SUCCESS = 0x00
+    PARAM_NOT_PAIRED = 0x01
+    PARAM_NOT_READABLE = 0x02
+    WRONG_KEY = 0x03
+    # Credential-management (keypad / RFID / fingerprint / palm) errors, not
+    # mechanical faults.
+    KEYCODE_DISABLE = 0x04
+    KEYCODE_INVALID_ACCESS = 0x05
+    KEYCODE_EXISTING_KEY = 0x06
+    KEYCODE_NOSPACE = 0x07
+    KEYCODE_TIMEOUT = 0x08
+    KEYCODE_DIS_ONETOUCH = 0x09
+    RFID_EXISTING_ID = 0x0A
+    FINGERPRINT_EXISTING_ID = 0x0B
+    PALM_EXISTING_ID = 0x0D
+    # Mechanical / motor faults (a stalled motor / jam).
+    MECH_TIMEOUT = 0x1E
+    MECH_POSITION = 0x1F
+    MECH_MOTPOL = 0x20
+    MECH_TIMEOUT_CAL = 0x21
+    MECH_BACKOFF = 0x22
+    MECH_HANDLE_NOT_LIFTED = 0x23
+    EMPTY_LOG = 0x28
+    READING_LOG = 0x29
+    VBAT_LOW = 0x32
+    OVERTEMP = 0x33
+    MAG_READ = 0x34
+    MAG_BAD_DATA = 0x35
+    INVALID_OPERATION = 0x37
+    NOT_AUTHORIZED = 0x38
+    NO_BUFS = 0x39
+    INVALID_MSG = 0x3A
+    NACK = 0x3B
+    UNKNOWN = 0x3C
+    UNINITIALIZED = 0x3D
+    BUSY = 0x3E
+    NOT_FOUND = 0x3F
+    SSID_IS_5GHZ = 0x40
+    DHCP_FAILURE = 0x41
+    DNS_FAILURE = 0x42
+    CAL_BAD_EXTENTS = 0x43
+    CAL_BAD_ANGLE = 0x44
+    KEYCODE_SLOT_IN_USE = 0x45
+    EXT_TIMEOUT = 0x46
+
+
+VALUE_TO_OPERATION_ERROR = {err.value: err for err in OperationError}
+
+
 class StatusType(IntEnum):
     LOCK_ONLY = 0x02
     DOOR_ONLY = 0x2E
@@ -53,11 +111,10 @@ class LockStatus(Enum):
     LOCKING = 0x04
     LOCKED = 0x05
     UNKNOWN_06 = 0x06  # PolDiscovery
-    # STATICPOSITION = 0x07
+    JAMMED = 0x07  # STATICPOSITION
     # UNLATCHING = 0x09
     # UNLATCHED = 0x0A
     SECUREMODE = 0x0C
-    JAMMED = 0x1B  # Lock jammed / motor stalled
 
 
 VALUE_TO_LOCK_STATUS = {status.value: status for status in LockStatus}

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -26,6 +26,7 @@ from .const import (
     VALUE_TO_LOCK_OPERATION_REMOTE_TYPE,
     VALUE_TO_LOCK_OPERATION_SOURCE,
     VALUE_TO_LOCK_STATUS,
+    VALUE_TO_OPERATION_ERROR,
     AutoLockMode,
     AutoLockState,
     BatteryState,
@@ -39,6 +40,7 @@ from .const import (
     LockOperationSource,
     LockStateValue,
     LockStatus,
+    OperationError,
     SettingType,
     StatusType,
 )
@@ -128,6 +130,11 @@ class Lock:
         self._lock_info = info
         self.client: BleakClientWithServiceCache | None = None
         self._state_callback = state_callback
+        # byte[15] of the most recent op-response: 0x00 success, non-zero =
+        # OperationError enum value (MECH_* = jam). None until the first op.
+        # Retained so a follow-up can expose the failure reason as a
+        # diagnostic.
+        self._last_op_error: int | None = None
         self._disconnected = False
         self._disconnect_callback = disconnect_callback
         self._disconnected_futures: set[asyncio.Future[None]] = set()
@@ -217,17 +224,27 @@ class Lock:
 
     def _parse_state(self, state: bytes) -> Iterable[LockStateValue] | None:
         if state[0] == 0xBB:
-            # Check for LOCK/UNLOCK command responses (0xBB + 0x0A/0x0B)
-            # These can contain actual status in byte[3] when operation fails/jams
+            # Op-response for LOCK/UNLOCK (0xBB + 0x0A/0x0B), emitted when the
+            # motor stops. The operation result is byte[15]: 0x00 = success,
+            # any non-zero = failure (0x1E-0x23 = MECH_* motor stall / jam).
             if (
                 state[1] in (Commands.LOCK.value, Commands.UNLOCK.value)
-                and len(state) > 3
+                and len(state) > 0x0F
             ):
-                lock_status_byte = state[0x03]
-                if lock_status_byte in VALUE_TO_LOCK_STATUS:
-                    return [VALUE_TO_LOCK_STATUS[lock_status_byte]]
+                result = state[0x0F]
+                self._last_op_error = result
+                if result != OperationError.COMM_SUCCESS:
+                    error = VALUE_TO_OPERATION_ERROR.get(result)
+                    _LOGGER.warning(
+                        "%s: Operation failed with result 0x%02X (%s)",
+                        self.name,
+                        result,
+                        error.name if error else "unknown",
+                    )
+                    return [LockStatus.JAMMED]
+                return ()  # success: recognized, no state update
             if state[1] == Commands.LOCK_ACTIVITY.value:
-                return None  # Ignore lock activity as these are historical events
+                return ()  # Ignore lock activity as these are historical events
             if state[1] == Commands.GETSTATUS.value:
                 if state[4] == StatusType.LOCK_ONLY.value:
                     lock_status = state[0x08]
@@ -255,10 +272,14 @@ class Lock:
     def _internal_state_callback(self, state: bytes) -> None:
         """Handle state change."""
         _LOGGER.debug("%s: State changed: %s", self.name, state.hex())
-        if (parsed_state := self._parse_state(state)) is not None:
-            self._state_callback(parsed_state)
-        else:
+        parsed_state = self._parse_state(state)
+        if parsed_state is None:
+            # Unrecognized frame - surface it for diagnosis.
             _LOGGER.info("%s: Unknown state: %s", self.name, state.hex())
+        elif parsed_state:
+            # Non-empty iterable - emit the state(s) to the consumer.
+            self._state_callback(parsed_state)
+        # else: empty () - a recognized frame that carries no state update; ignore.
 
     async def _setup_session(self) -> None:
         """Setup the session."""

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from collections.abc import Callable, Iterable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,11 +11,13 @@ from yalexs_ble.const import (
     FIRMWARE_REVISION_CHARACTERISTIC,
     MODEL_NUMBER_CHARACTERISTIC,
     SERIAL_NUMBER_CHARACTERISTIC,
+    VALUE_TO_LOCK_STATUS,
     AutoLockMode,
     AutoLockState,
     LockInfo,
     LockOperationRemoteType,
     LockOperationSource,
+    LockStateValue,
     LockStatus,
 )
 from yalexs_ble.lock import (
@@ -133,87 +136,221 @@ def test_parse_operation_source() -> None:
 
 
 def test_parse_lock_command_response_jammed() -> None:
-    """Test parsing LOCK command response with JAMMED status."""
-    lock = Lock(
-        lambda: BLEDevice("aa:bb:cc:dd:ee:ff", "lock"),
-        "0800200c9a66",
-        1,
-        "mylock",
-        lambda _: None,
-    )
+    """LOCK op-response with a MECH_* result (byte[15]) parses as JAMMED."""
+    lock = _make_lock()
 
-    # Frame: bb0b001b00000000000000000000001f0000
-    # 0xBB = Status response, 0x0B = LOCK command, byte[3] = 0x1B = JAMMED
+    # Real lock-jam capture: byte[15] = 0x1F MECH_POSITION. byte[3] (0x1B
+    # here) is only the frame checksum, not a status.
     frame = bytes.fromhex("bb0b001b00000000000000000000001f0000")
     result = lock._parse_state(frame)
 
     assert result is not None
-    result_list = list(result)
-    assert len(result_list) == 1
-    assert result_list[0] is LockStatus.JAMMED
+    assert list(result) == [LockStatus.JAMMED]
 
 
-def test_parse_lock_command_response_unlocked() -> None:
-    """Test parsing LOCK command response with UNLOCKED (jam as unlocked)."""
-    lock = Lock(
-        lambda: BLEDevice("aa:bb:cc:dd:ee:ff", "lock"),
-        "0800200c9a66",
-        1,
-        "mylock",
-        lambda _: None,
-    )
+def test_parse_unlock_command_response_jammed() -> None:
+    """UNLOCK op-response with a MECH_* result (byte[15]) parses as JAMMED.
 
-    # Frame: bb0b00030000000000000000000000370000
-    # 0xBB = Status response, 0x0B = LOCK command, byte[3] = 0x03 = UNLOCKED
-    frame = bytes.fromhex("bb0b00030000000000000000000000370000")
+    The old byte[3] path missed this: an unlock jam's checksum is 0x1C, not
+    the 0x1B it looked for. The result is in byte[15] (0x1F MECH_POSITION)
+    regardless of direction.
+    """
+    lock = _make_lock()
+
+    frame = bytes.fromhex("bb0a001c00000000000000000000001f0000")
     result = lock._parse_state(frame)
 
     assert result is not None
-    result_list = list(result)
-    assert len(result_list) == 1
-    assert result_list[0] is LockStatus.UNLOCKED
+    assert list(result) == [LockStatus.JAMMED]
 
 
-def test_parse_unlock_command_response() -> None:
-    """Test parsing UNLOCK command response."""
-    lock = Lock(
-        lambda: BLEDevice("aa:bb:cc:dd:ee:ff", "lock"),
-        "0800200c9a66",
-        1,
-        "mylock",
-        lambda _: None,
-    )
+def test_parse_lock_command_response_success_is_no_update() -> None:
+    """A successful LOCK op-response (byte[15]=0x00) carries no state update.
 
-    # Frame: bb0a00030000000000000000000000000000
-    # 0xBB = Status response, 0x0A = UNLOCK command, byte[3] = 0x03 = UNLOCKED
-    frame = bytes.fromhex("bb0a00030000000000000000000000000000")
+    The op-response reports the result of the issued command; which state
+    resulted is known to the command issuer, not the parser (lock and
+    securemode op-responses are byte-identical), so the parser emits nothing.
+    """
+    lock = _make_lock()
+
+    frame = bytes.fromhex("bb0b003a0000000000000000000000000000")
     result = lock._parse_state(frame)
 
     assert result is not None
-    result_list = list(result)
-    assert len(result_list) == 1
-    assert result_list[0] is LockStatus.UNLOCKED
+    assert list(result) == []
 
 
-def test_parse_lock_command_response_locked_success() -> None:
-    """Test parsing LOCK command response with successful LOCKED status."""
-    lock = Lock(
-        lambda: BLEDevice("aa:bb:cc:dd:ee:ff", "lock"),
-        "0800200c9a66",
-        1,
-        "mylock",
-        lambda _: None,
-    )
+def test_parse_unlock_command_response_success_is_no_update() -> None:
+    """A successful UNLOCK op-response (byte[15]=0x00) carries no state update."""
+    lock = _make_lock()
 
-    # Frame: bb0b00050000000000000000000000000000
-    # 0xBB = Status response, 0x0B = LOCK command, byte[3] = 0x05 = LOCKED
-    frame = bytes.fromhex("bb0b00050000000000000000000000000000")
+    frame = bytes.fromhex("bb0a003b0000000000000000000000000000")
     result = lock._parse_state(frame)
 
     assert result is not None
-    result_list = list(result)
-    assert len(result_list) == 1
-    assert result_list[0] is LockStatus.LOCKED
+    assert list(result) == []
+
+
+def test_parse_getstatus_staticposition() -> None:
+    """A settled GETSTATUS lock state of 0x07 (STATICPOSITION) parses as JAMMED."""
+    lock = _make_lock()
+
+    # bb02 GETSTATUS, byte[4]=0x02 LOCK_ONLY, byte[8]=0x07 (settled jam state).
+    frame = bytes.fromhex("bb02003a0200000007000000000000000000")
+    result = lock._parse_state(frame)
+
+    assert result is not None
+    assert list(result) == [LockStatus.JAMMED]
+
+
+def test_parse_success_op_response_with_0200_trailer_is_no_update(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The issue #317 fixture: byte[3] shifts with the plaintext trailer.
+
+    A successful unlock op-response with the ``0200`` CommandType trailer
+    moves byte[3] to 0x39. Keying off byte[3] would miss it; keying off
+    byte[15]=0x00 recognizes it as a successful op-response with no state
+    update -- and it must not log "Unknown state".
+    """
+    lock = _make_lock()
+
+    frame = bytes.fromhex("bb0a00390000000000000000000000000200")
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        result = lock._parse_state(frame)
+        lock._internal_state_callback(frame)
+
+    assert result is not None
+    assert list(result) == []
+    assert "Unknown state" not in caplog.text
+
+
+def test_parse_lock_activity_is_no_update(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A LOCK_ACTIVITY (0xBB 0x2D) frame is recognized with no state update."""
+    lock = _make_lock()
+
+    frame = bytes.fromhex("bb2d008000000000000000000000000000")
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        result = lock._parse_state(frame)
+        lock._internal_state_callback(frame)
+
+    assert result is not None
+    assert list(result) == []
+    assert "Unknown state" not in caplog.text
+
+
+def test_parse_non_mech_error_is_jammed_and_logs_decoded_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-MECH failure result still parses as JAMMED and logs its name."""
+    lock = _make_lock()
+
+    # byte[15] = 0x32 VBAT_LOW (synthetic; no real capture for a non-MECH error).
+    # Captured at WARNING: an operation failure must be visible at default
+    # log levels, not only in a debug session.
+    frame = bytes.fromhex("bb0b00000000000000000000000000320000")
+    with caplog.at_level("WARNING", logger="yalexs_ble.lock"):
+        result = lock._parse_state(frame)
+
+    assert result is not None
+    assert list(result) == [LockStatus.JAMMED]
+    assert "0x32" in caplog.text
+    assert "VBAT_LOW" in caplog.text
+
+
+def test_parse_unknown_error_code_is_jammed_and_logs_unknown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unmapped non-zero result is JAMMED and logs the raw value as unknown."""
+    lock = _make_lock()
+
+    frame = bytes.fromhex("bb0b00000000000000000000000000770000")
+    with caplog.at_level("WARNING", logger="yalexs_ble.lock"):
+        result = lock._parse_state(frame)
+
+    assert result is not None
+    assert list(result) == [LockStatus.JAMMED]
+    assert "0x77" in caplog.text
+    assert "unknown" in caplog.text
+
+
+def test_last_op_error_is_retained() -> None:
+    """The op-response result byte[15] is retained on the lock instance."""
+    # Collected and compared once: asserting on the attribute per step narrows
+    # it (mypy keeps the narrowing across the _parse_state call) and the later
+    # steps are then flagged unreachable.
+    lock = _make_lock()
+    seen: list[int | None] = [lock._last_op_error]
+
+    lock._parse_state(bytes.fromhex("bb0b001b00000000000000000000001f0000"))
+    seen.append(lock._last_op_error)
+
+    lock._parse_state(bytes.fromhex("bb0b003a0000000000000000000000000000"))
+    seen.append(lock._last_op_error)
+
+    assert seen == [None, 0x1F, 0x00]
+
+
+def test_parse_bogus_frame_is_none_and_logs_unknown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A frame with an unrecognized flag byte is not recognized and still logs."""
+    lock = _make_lock()
+
+    frame = bytes.fromhex("cc00000000000000000000000000000000")
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        assert lock._parse_state(frame) is None
+        lock._internal_state_callback(frame)
+
+    assert "Unknown state" in caplog.text
+
+
+def test_parse_ack_still_reports_state() -> None:
+    """The AA transport-ack path is unchanged by the op-response decode."""
+    lock = _make_lock()
+
+    result = lock._parse_state(bytes.fromhex("aa0b00490000000000000000000000000200"))
+    assert result is not None
+    assert list(result) == [LockStatus.LOCKED]
+
+
+def test_parse_settings_read_ack_is_none_and_logs_unknown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An AA ack echoing a non-operation command is not recognized as state.
+
+    Production capture: the ack to the startup auto-lock READSETTING (command
+    0x04 echoed in byte[1], setting 0x28 in byte[4]). Only the Lock/Unlock
+    acks carry a state meaning; other acks surface via the unknown-state log.
+    """
+    lock = _make_lock()
+
+    frame = bytes.fromhex("aa0400282800000000000000000000000200")
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        assert lock._parse_state(frame) is None
+        lock._internal_state_callback(frame)
+
+    assert "Unknown state" in caplog.text
+
+
+def test_internal_state_callback_emits_recognized_state() -> None:
+    """A recognized frame with state content reaches the state callback."""
+    received: list[list[LockStateValue]] = []
+    lock = _make_lock(lambda states: received.append(list(states)))
+
+    # Settled status push after a jam: GETSTATUS/LOCK_ONLY with state 0x07
+    # (production capture).
+    lock._internal_state_callback(bytes.fromhex("bb02003a0200000007000000000000000000"))
+
+    assert received == [[LockStatus.JAMMED]]
+
+
+def test_jammed_maps_to_the_settled_static_position_value() -> None:
+    """JAMMED is the settled post-jam status value 0x07 (STATICPOSITION)."""
+    assert LockStatus(0x07) is LockStatus.JAMMED
+    assert VALUE_TO_LOCK_STATUS[0x07] is LockStatus.JAMMED
 
 
 def _make_auto_lock_response(mode_byte: int, duration: int) -> bytes:
@@ -221,13 +358,15 @@ def _make_auto_lock_response(mode_byte: int, duration: int) -> bytes:
     return bytes(8) + duration.to_bytes(2, "little") + bytes([mode_byte])
 
 
-def _make_lock() -> Lock:
+def _make_lock(
+    state_callback: Callable[[Iterable[LockStateValue]], None] = lambda _: None,
+) -> Lock:
     return Lock(
         lambda: BLEDevice("aa:bb:cc:dd:ee:ff", "lock"),
         "0800200c9a66",
         1,
         "mylock",
-        lambda _: None,
+        state_callback,
     )
 
 


### PR DESCRIPTION
### What this fixes

Every mechanical operation ends with an operation-response frame (`0xBB` +
the echoed opcode), emitted when the motor stops. Two response opcodes cover
everything: the Lock opcode (`0xBB 0x0B`) covers lock and secure, and the
Unlock opcode (`0xBB 0x0A`) covers unlock and unlatch; a command byte selects
the variant. The lock emits the same frames for jams from local operations started manually at the
lock or via the Yale Home app, so this one decode handles every operation.
The actual result lives in **byte[15]**, and the enum OperationError names its values. `0x00` is success,
any non-zero value is a failure, and `0x1E-0x23` are the `MECH_*` motor
faults (a stalled motor — a jam).

```mermaid
packet-beta
  title "Response/Unlock (0xBB 0x0A) / Response/Lock (0xBB 0x0B) - 18 bytes"
  0-7: "byte[0] 0xBB"
  8-15: "byte[1] 0x0A/0x0B"
  16-23: "byte[2] 0x00"
  24-31: "byte[3] Checksum"
  32-119: "bytes[4]-[14] 0x00 (unused)"
  120-127: "byte[15] Error/result"
  128-143: "bytes[16:17] CommandType"
```

The parser currently keys this frame off **byte[3]**, which is the
whole-frame checksum rather than a status byte. Three consequences:

- #283 observed lock jams producing byte[3] = 0x1B. But byte[3] is the
  checksum, so the match only holds for the lock direction: an
  unlock jam's checksum is `0x1C`, so unlock-direction jams are missed.
- The checksum also covers the CommandType trailer (`[16:17]`)
  which can vary — issue #317.
- After a jam, the settled status (`0xBB 0x02`) reports lock state `0x07`
  (UnknownStaticPosition). That value is unmapped, so it resolves to
  `UNKNOWN` and overwrites the earlier `JAMMED` about 20 ms later; template
  locks downstream then log "Received invalid lock state: unknown".

### The change

- Parse the operation response from byte[15]: any non-zero result emits
  `JAMMED` plus a WARNING log with the decoded error name; a success result
  is recognized with no state update.
- Retain the last result on the `Lock` instance (`_last_op_error`) for a
  follow-up that could expose the failure reason as a diagnostic.
- LockStatus.JAMMED takes the value 0x07 (STATICPOSITION / UnknownStaticPosition — the settled state after a jam).
  A status `0x07` now decodes to `JAMMED`, so the jam sticks.
- Add an `OperationError` enum and a `VALUE_TO_OPERATION_ERROR` table to
  `const.py` — the native byte[15] Error values, so a failure log names the
  actual cause (MECH_POSITION, VBAT_LOW, ...).

The transport-ACK path (`0xAA`) and the operation flow are unchanged — this
is a parse-layer fix. One API note: `LockStatus.JAMMED.value` moves from
`0x1B` to `0x07`. Consumers compare members (Home Assistant does) and are
unaffected; a raw-value comparison against `0x1B` never matched a real
frame.

### Known limit

Detection only: after a jam these locks may lose track of their actual physical
position and, as in my captures, subsequent polls may report a locked/unlocked
state instead of a jam, replacing `JAMMED` as the displayed state.
Keeping the jam visible for the
user is a separate proposal I'd like to follow up with (locally I am folding
`JAMMED` into incoming status messages for up to 30 s); this PR makes the
detection and logging correct first.

### Field validation

Two YUR-family locks, captures from 2026-07-05 through 2026-07-08: byte[15]
jam detection fired on 14/14 commanded jams; the status `0x07` followed
every jam whether the operation was commanded over BLE, by the lock's
button, or from the app.

### Relationship to other work

- Completes #283 (thanks @philbert — detection moves to byte[15] and now
  covers unlock-direction jams too; `JAMMED` moves onto the settled value
  the lock sends, since `0x1B` was the byte[3] checksum).
- Closes #317 (@kwv — normal operation responses are recognized without log
  noise; built on #318's test helpers).
- Overlaps the parse portion of #319 (@bluetoothbot — adopts the same
  recognized-frame-stays-silent convention; the result byte differs for the
  checksum reasons above).
