### PR TITLE
ci: require 100% patch coverage in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%


### PR DESCRIPTION
## Summary
Codecov was falling back to the default auto patch target, so PRs showed a 31% patch target; the real expectation is 100% and contributors had to be told that in review. This adds a codecov.yml that sets the patch status target to 100% so CI reflects it directly.

## Test plan
- [ ] Codecov patch status on this PR reports the 100% target
